### PR TITLE
respect specified sdk when launching

### DIFF
--- a/Simulator.m
+++ b/Simulator.m
@@ -81,11 +81,9 @@
         return EXIT_FAILURE;
     }
     
-    DTiPhoneSimulatorSystemRoot *sdkRoot = [DTiPhoneSimulatorSystemRoot defaultRoot];
-    
     DTiPhoneSimulatorSessionConfig *config = [[DTiPhoneSimulatorSessionConfig alloc] init];
     [config setApplicationToSimulateOnStart:appSpec];
-    [config setSimulatedSystemRoot:sdkRoot];
+    [config setSimulatedSystemRoot:_sdk];
 	[config setSimulatedDeviceFamily:_family];
     [config setSimulatedApplicationShouldWaitForDebugger:NO];    
     [config setSimulatedApplicationLaunchArgs:_args];


### PR DESCRIPTION
For some reason, launching grabs

```
+ [DTiPhoneSimulatorSystemRoot defaultRoot]
```

instead of one created during initialization. Quick change to use the specified root.
