### PR TITLE
Fix problem when Xcode is not installed in /Developer.

### DIFF
--- a/WaxSim.xcodeproj/project.pbxproj
+++ b/WaxSim.xcodeproj/project.pbxproj
@@ -168,7 +168,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = WaxSim_Prefix.pch;
 				INSTALL_PATH = /usr/local/bin;
-				LD_RUNPATH_SEARCH_PATHS = /Developer/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks;
+				LD_RUNPATH_SEARCH_PATHS = "\"$(DEVELOPER_DIR)/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks\"";
 				PRODUCT_NAME = waxsim;
 			};
 			name = Debug;
@@ -187,7 +187,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = WaxSim_Prefix.pch;
 				INSTALL_PATH = /usr/local/bin;
-				LD_RUNPATH_SEARCH_PATHS = /Developer/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks;
+				LD_RUNPATH_SEARCH_PATHS = "\"$(DEVELOPER_DIR)/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks\"";
 				PRODUCT_NAME = waxsim;
 			};
 			name = Release;


### PR DESCRIPTION
Fix problem when Xcode is not installed in /Developer.  The error message was 'dyld: Library not loaded: @rpath/iPhoneSimulatorRemoteClient.framework/Versions/A/iPhoneSimulatorRemoteClient'

I have several Xcodes installed on my machine (3.2.6, 4.0.2 and betas) and I am mainly using Xcode 4.0.2 right now, installed in /Xcode4.0.2 - this caused the above error.

Basically this synchronizes "Runtime Search Paths" with "Framework Search Paths", which already had the value "$(DEVELOPER_DIR)/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks" .