### PR TITLE
Accept '-t' option to set Simulator timeout on launch.

### DIFF
--- a/Simulator.h
+++ b/Simulator.h
@@ -22,13 +22,14 @@
     CGWindowID _windowID;
     QTMovie *_movie;
     NSTimeInterval _lastInterval;
+    NSInteger _timeout;
 }
 
 @property (nonatomic, readonly) DTiPhoneSimulatorSession* session;
 
 + (NSArray *)availableSDKs;
 
-- (id)initWithAppPath:(NSString *)appPath sdk:(NSString *)sdk family:(NSString *)family video:(NSString *)videoPath env:(NSDictionary *)env args:(NSArray *)args;
+- (id)initWithAppPath:(NSString *)appPath sdk:(NSString *)sdk family:(NSString *)family video:(NSString *)videoPath env:(NSDictionary *)env timeout:(NSInteger)timeout args:(NSArray *)args;
 - (int)launch;
 - (void)addScreenshotToMovie;
 - (void)end;

--- a/Simulator.m
+++ b/Simulator.m
@@ -19,7 +19,7 @@
 
 @synthesize session=_session;
 
-- (id)initWithAppPath:(NSString *)appPath sdk:(NSString *)sdk family:(NSString *)family video:(NSString *)videoPath env:(NSDictionary *)env args:(NSArray *)args;
+- (id)initWithAppPath:(NSString *)appPath sdk:(NSString *)sdk family:(NSString *)family video:(NSString *)videoPath env:(NSDictionary *)env timeout:(NSInteger)timeout args:(NSArray *)args;
 {
     self = [super init];
 
@@ -59,6 +59,7 @@
 	_env = [env retain];
 	_args = [args retain];
     _videoPath = [videoPath retain];
+    _timeout = timeout;
 
     return self;
 }
@@ -104,7 +105,7 @@
     [_session setDelegate:self];
     
     NSError *error;
-    if (![_session requestStartWithConfig:config timeout:30 error:&error]) {
+    if (![_session requestStartWithConfig:config timeout:_timeout error:&error]) {
         WaxLog(@"Could not start simulator session: %@", [error localizedDescription]);
         return EXIT_FAILURE;
     }

--- a/WaxSim.m
+++ b/WaxSim.m
@@ -12,6 +12,7 @@ int main(int argc, char *argv[]) {
     signal(SIGQUIT, resetSignal);
     
     int c;
+    int timeout = 30;
     char *sdk = nil;
 	char *family = nil;
     char *appPath = nil;
@@ -21,7 +22,7 @@ int main(int argc, char *argv[]) {
 	NSString *environment_variable;
 	NSArray *environment_variable_parts;
     
-    while ((c = getopt(argc, argv, "e:s:f:v:ah")) != -1) {
+    while ((c = getopt(argc, argv, "e:s:f:v:ah:t")) != -1) {
         switch(c) {
 			case 'e':
 				environment_variable = [NSString stringWithCString:optarg encoding:NSUTF8StringEncoding];
@@ -58,6 +59,9 @@ int main(int argc, char *argv[]) {
                 }
                 return 1;
                 break;
+            case 't':
+                timeout = atoi(optarg);
+                break;
             default:
                 abort ();
         }
@@ -84,7 +88,7 @@ int main(int argc, char *argv[]) {
     NSString *appPathString = [NSString stringWithUTF8String:appPath];
     NSString *videoPathString = videoPath ? [NSString stringWithUTF8String:videoPath] : nil;
 
-    Simulator *simulator = [[Simulator alloc] initWithAppPath:appPathString sdk:sdkString family:familyString video:videoPathString env:environment args:additionalArgs];
+    Simulator *simulator = [[Simulator alloc] initWithAppPath:appPathString sdk:sdkString family:familyString video:videoPathString env:environment timeout:timeout args:additionalArgs];
     [simulator launch];
 
     [[NSRunLoop mainRunLoop] run];

--- a/WaxSim.m
+++ b/WaxSim.m
@@ -22,7 +22,7 @@ int main(int argc, char *argv[]) {
 	NSString *environment_variable;
 	NSArray *environment_variable_parts;
     
-    while ((c = getopt(argc, argv, "e:s:f:v:ah:t")) != -1) {
+    while ((c = getopt(argc, argv, "e:s:f:v:t:ah")) != -1) {
         switch(c) {
 			case 'e':
 				environment_variable = [NSString stringWithCString:optarg encoding:NSUTF8StringEncoding];
@@ -48,6 +48,9 @@ int main(int argc, char *argv[]) {
             case 'v':
                 videoPath = optarg;
                 break;
+            case 't':
+                timeout = atoi(optarg);
+                break;
             case '?':
                 if (optopt == 's' || optopt == 'f') {
                     fprintf(stderr, "Option -%c requires an argument.\n", optopt);
@@ -58,9 +61,6 @@ int main(int argc, char *argv[]) {
                     printUsage();
                 }
                 return 1;
-                break;
-            case 't':
-                timeout = atoi(optarg);
                 break;
             default:
                 abort ();
@@ -104,6 +104,7 @@ void printUsage() {
     fprintf(stderr, "\t-e VAR=value\tEnvironment variable to set (-e CFFIXED_HOME=/tmp/iphonehome)\n");
     fprintf(stderr, "\t-a \tAvailable SDKs\n");
     fprintf(stderr, "\t-v path\tOutput video recording at path\n");
+    fprintf(stderr, "\t-t timeout\tseconds before giving up on the simulator\n");
     fprintf(stderr, "\t-h \tPrints out this wonderful documentation!\n");    
 }
 


### PR DESCRIPTION
I've had situations on an underpowered test box where it will finish launching the simulator just after the 30 seconds are up.

This patch defaults the timeout to 30 seconds, but will allow arbitrary timeout with the -t flag