### PR TITLE
Fixing WaxSim to honor provided SDK

### DIFF
--- a/Simulator.m
+++ b/Simulator.m
@@ -81,7 +81,7 @@
         return EXIT_FAILURE;
     }
     
-    DTiPhoneSimulatorSystemRoot *sdkRoot = [DTiPhoneSimulatorSystemRoot defaultRoot];
+    DTiPhoneSimulatorSystemRoot *sdkRoot = _sdk;
     
     DTiPhoneSimulatorSessionConfig *config = [[DTiPhoneSimulatorSessionConfig alloc] init];
     [config setApplicationToSimulateOnStart:appSpec];


### PR DESCRIPTION
We use both the 4.3 and 5.0 versions of the iPhone Simulator, and WaxSim was always using 5.0, which lead me to find that the sdk used was always the default. This fixes that.