### PR TITLE
Xcode 4.3 and 4.2 fix for LD_RUNPATH_SEARCH_PATHS

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,0 +1,40 @@
+# WaxSim
+
+A wrapper around iPhoneSimulatorRemoteClient, to install and run apps in the iOS simulator.
+
+## Installation
+
+Compiling and installing uses the `xcodebuild` command. By default it installs the app in `/usr/local/bin`.
+
+`xcodebuild install`
+
+To customize the installation location use the `DSTROOT` and `INSTALL_PATH` build variables. For example, to compile into a local `bin` directory:
+
+`xcodebuild install DSTROOT=. INSTALL_PATH=/bin`
+
+## Use
+
+`waxsim "/path/to/MyApp.app"`
+
+If you want to define which family of iOS device to use:
+
+`waxsim -f "ipad" "/path/to/MyApp.app"`
+
+To see all usage options, type `waxsim` with no arguments:
+
+```
+usage: waxsim [options] app-path
+example: waxsim -s 2.2 /path/to/app.app
+Available options are:
+  -s sdkVersion number of sdk to use (-s 3.1)
+  -f familyDevice to use (-f ipad)
+  -e VAR=valueEnvironment variable to set (-e CFFIXED_HOME=/tmp/iphonehome)
+  -a DependenciesAvailable SDKs
+  -v pathOutput video recording at path
+  -h DependenciesPrints out this wonderful documentation!
+```
+
+## Dependencies
+
+You need to be runnin Mac OS X running a recent version of Xcode. Testing with Xcode 4.5.
+

--- a/Simulator.m
+++ b/Simulator.m
@@ -81,11 +81,9 @@
         return EXIT_FAILURE;
     }
     
-    DTiPhoneSimulatorSystemRoot *sdkRoot = [DTiPhoneSimulatorSystemRoot defaultRoot];
-    
     DTiPhoneSimulatorSessionConfig *config = [[DTiPhoneSimulatorSessionConfig alloc] init];
     [config setApplicationToSimulateOnStart:appSpec];
-    [config setSimulatedSystemRoot:sdkRoot];
+    [config setSimulatedSystemRoot:_sdk];
 	[config setSimulatedDeviceFamily:_family];
     [config setSimulatedApplicationShouldWaitForDebugger:NO];    
     [config setSimulatedApplicationLaunchArgs:_args];

--- a/WaxSim.xcodeproj/project.pbxproj
+++ b/WaxSim.xcodeproj/project.pbxproj
@@ -200,10 +200,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+				DSTROOT = /;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				INSTALL_PATH = /usr/local/bin;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
 			};
@@ -213,9 +215,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+				DSTROOT = /;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				INSTALL_PATH = /usr/local/bin;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
 			};

--- a/WaxSim.xcodeproj/project.pbxproj
+++ b/WaxSim.xcodeproj/project.pbxproj
@@ -168,7 +168,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = WaxSim_Prefix.pch;
 				INSTALL_PATH = /usr/local/bin;
-				LD_RUNPATH_SEARCH_PATHS = /Developer/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks;
+				LD_RUNPATH_SEARCH_PATHS = "\"$(DEVELOPER_DIR)/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks\" $(DEVELOPER_DIR)/../OtherFrameworks";
 				PRODUCT_NAME = waxsim;
 			};
 			name = Debug;
@@ -187,7 +187,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = WaxSim_Prefix.pch;
 				INSTALL_PATH = /usr/local/bin;
-				LD_RUNPATH_SEARCH_PATHS = /Developer/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks;
+				LD_RUNPATH_SEARCH_PATHS = "\"$(DEVELOPER_DIR)/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks\" $(DEVELOPER_DIR)/../OtherFrameworks";
 				PRODUCT_NAME = waxsim;
 			};
 			name = Release;

--- a/WaxSim.xcodeproj/project.pbxproj
+++ b/WaxSim.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 45;
+	objectVersion = 46;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -122,8 +122,11 @@
 /* Begin PBXProject section */
 		08FB7793FE84155DC02AAC07 /* Project object */ = {
 			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0450;
+			};
 			buildConfigurationList = 1DEB927808733DD40010E9CD /* Build configuration list for PBXProject "WaxSim" */;
-			compatibilityVersion = "Xcode 3.1";
+			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 1;
 			knownRegions = (
@@ -161,7 +164,6 @@
 					"\"$(DEVELOPER_DIR)/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks\"",
 				);
 				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_ENABLE_FIX_AND_CONTINUE = YES;
 				GCC_ENABLE_OBJC_GC = supported;
 				GCC_MODEL_TUNING = G5;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -201,7 +203,6 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				PREBINDING = NO;
 				SDKROOT = macosx;
 			};
 			name = Debug;
@@ -214,7 +215,6 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				PREBINDING = NO;
 				SDKROOT = macosx;
 			};
 			name = Release;

--- a/WaxSim.xcodeproj/project.pbxproj
+++ b/WaxSim.xcodeproj/project.pbxproj
@@ -202,7 +202,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				PREBINDING = NO;
-				SDKROOT = macosx10.6;
+				SDKROOT = macosx;
 			};
 			name = Debug;
 		};
@@ -215,7 +215,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				PREBINDING = NO;
-				SDKROOT = macosx10.6;
+				SDKROOT = macosx;
 			};
 			name = Release;
 		};

--- a/WaxSim.xcodeproj/project.pbxproj
+++ b/WaxSim.xcodeproj/project.pbxproj
@@ -171,6 +171,7 @@
 				GCC_PREFIX_HEADER = WaxSim_Prefix.pch;
 				INSTALL_PATH = /usr/local/bin;
 				LD_RUNPATH_SEARCH_PATHS = "\"$(DEVELOPER_DIR)/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks\" $(DEVELOPER_DIR)/../OtherFrameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				PRODUCT_NAME = waxsim;
 			};
 			name = Debug;
@@ -190,6 +191,7 @@
 				GCC_PREFIX_HEADER = WaxSim_Prefix.pch;
 				INSTALL_PATH = /usr/local/bin;
 				LD_RUNPATH_SEARCH_PATHS = "\"$(DEVELOPER_DIR)/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks\" $(DEVELOPER_DIR)/../OtherFrameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				PRODUCT_NAME = waxsim;
 			};
 			name = Release;


### PR DESCRIPTION
Inspired by this pull request that worked in Xcode 4.3 but breaks
previous versions of Xcode.

  https://github.com/square/WaxSim/pull/5

Using the $(DEVELOPER_DIR) environment variable, we can let Xcode figure
out the right root for us to set up the runtime search paths.