### PR TITLE
WaxSim with Xcode 4.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# WaxSim
+While Apple doesn’t provide an “official” way to launch an app in the iOS Simulator from the command line, there’s a way to do it with WaxSim.
+
+## Installation
+Installation process is straight forward, all you need is to:
+
+- Clone repo
+  
+  `git clone git@github.com:Taptera/WaxSim.git`
+- Go to project directory
+  
+  `cd WaxSim`
+- Build and install
+  
+  `xcodebuild install DSTROOT=/`
+
+Last command will build and copy `waxsim` executable file in yours `/usr/local/bin/`.
+
+## Usage
+In order to run simulator using waxsim you need to call:
+
+  `waxsim [application path]`

--- a/WaxSim.xcodeproj/project.pbxproj
+++ b/WaxSim.xcodeproj/project.pbxproj
@@ -168,7 +168,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = WaxSim_Prefix.pch;
 				INSTALL_PATH = /usr/local/bin;
-				LD_RUNPATH_SEARCH_PATHS = /Developer/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks;
+				LD_RUNPATH_SEARCH_PATHS = "$(DEVELOPER_DIR)/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks $(DEVELOPER_DIR)/../OtherFrameworks";
 				PRODUCT_NAME = waxsim;
 			};
 			name = Debug;
@@ -187,7 +187,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = WaxSim_Prefix.pch;
 				INSTALL_PATH = /usr/local/bin;
-				LD_RUNPATH_SEARCH_PATHS = /Developer/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks;
+				LD_RUNPATH_SEARCH_PATHS = "$(DEVELOPER_DIR)/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks $(DEVELOPER_DIR)/../OtherFrameworks";
 				PRODUCT_NAME = waxsim;
 			};
 			name = Release;


### PR DESCRIPTION
Hey,

I have to start with saying, great work with WaxSim! But lately I have encountered a problem with using it with Xcode 4.3. All this was due to that Apple have changed frameworks directories. We have fixed it by setting new runpath. Maybe you would like those changes on your's repo as well.

Lukasz